### PR TITLE
Improved Windows support

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -6,6 +6,8 @@ from __future__ import print_function
 import re
 import sys
 import os
+import subprocess
+
 if os.name == 'nt':
     from ctypes import windll, c_ulong
 
@@ -22,12 +24,6 @@ except Exception:
     # python3
     from ArgParse import ArgumentParser
     import ArgParse
-try:
-    import commands
-except Exception:
-    # python3
-    import subprocess as commands
-    commands.get_output = commands.check_output
 
 
 def colorize(color, message):
@@ -259,7 +255,11 @@ def is_excluded(path, options):
 def run(command, options):
     if options.verbose:
         print("running %s" % command)
-    return commands.getstatusoutput(command)
+    try:
+        output = subprocess.check_output(command, shell=True)
+        return 0, output
+    except subprocess.CalledProcessError, e:
+        return e.returncode, e.output
 
 
 def check(dirname, options):

--- a/clustergit
+++ b/clustergit
@@ -64,15 +64,15 @@ class Colors:
     }
 
 
-def write_color(out, colour):
+def write_color(out, color):
     # set text attribute for Windows and write ASCII color otherwise
     if os.name == 'nt' and out.isatty():
         windll.Kernel32.SetConsoleTextAttribute(
             windll.Kernel32.GetStdHandle(c_ulong(0xfffffff5)),
-            Colors.WIN_DICT[colour]
+            Colors.WIN_DICT[color]
         )
     else:
-        out.write(colour)
+        out.write(color)
 
 
 def write_with_color(out, msg):

--- a/clustergit
+++ b/clustergit
@@ -66,7 +66,7 @@ class Colors:
 
 def write_color(out, str):
     # set text attribute for Windows and write ASCII color otherwise
-    if os.name == 'nt':
+    if os.name == 'nt' and out.isatty():
         windll.Kernel32.SetConsoleTextAttribute(
             windll.Kernel32.GetStdHandle(c_ulong(0xfffffff5)),
             Colors.WIN_DICT[str]

--- a/clustergit
+++ b/clustergit
@@ -14,13 +14,13 @@ if os.name == 'nt':
 try:
     from argcomplete import autocomplete
     use_argcomplete = True
-except Exception:
+except ImportError:
     use_argcomplete = False
     # print('Notice: install "argcomplete" to automatic complete the arguments')
 try:
     from argparse import ArgumentParser
     import argparse
-except Exception:
+except ImportError:
     # python3
     from ArgParse import ArgumentParser
     import ArgParse
@@ -64,20 +64,20 @@ class Colors:
     }
 
 
-def write_color(out, str):
+def write_color(out, colour):
     # set text attribute for Windows and write ASCII color otherwise
     if os.name == 'nt' and out.isatty():
         windll.Kernel32.SetConsoleTextAttribute(
             windll.Kernel32.GetStdHandle(c_ulong(0xfffffff5)),
-            Colors.WIN_DICT[str]
+            Colors.WIN_DICT[colour]
         )
     else:
-        out.write(str)
+        out.write(colour)
 
 
-def write_with_color(out, str):
+def write_with_color(out, msg):
     # build regex for splitting by colors, split and iterate over elements
-    for p in re.split(('(%s)' % '|'.join(Colors.ALL)).replace('[', '\['), str):
+    for p in re.split(('(%s)' % '|'.join(Colors.ALL)).replace('[', '\['), msg):
         # check if element is a color
         if p in Colors.ALL:
             write_color(out, p)

--- a/clustergit.cmd
+++ b/clustergit.cmd
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0\clustergit" %*


### PR DESCRIPTION
Opening this PR to address #24 and get some feedback. `clustergit` didn't work at all for me on Windows 10 with Git Bash so I decided to take a stab at this. :-)

What didn't work for me (using Git Bash):
```bash
$ ./clustergit -d /d/projects
Starting git status...
Scanning sub directories of D:/projects
Traceback (most recent call last):
  File "./clustergit", line 462, in <module>
    main(sys.argv[1:])
  File "./clustergit", line 442, in main
    new_gitted, new_dirties = check(path, options)
  File "./clustergit", line 311, in check
    branch = out.splitlines()[0].replace("On branch ", "")
IndexError: list index out of range
```
Which means that `commands.get_output` didn't return any output.

**Caveats:**
- only tested with Windows 10, but with both Command Prompt and Git Bash
- the minimum required python version is now 2.7 since `subprocess.check_output` didn't exist before that.
- I am not sure if the change from `commands.get_output` to `subprocess.check_output` covers all bases, but it worked for `clustergit -s` and `clustergit -p` with repositories that were either clean or had local changes, remote changes, or both.
- There are some cosmetic changes to make PyLint happy